### PR TITLE
Updated peek() function

### DIFF
--- a/MaxHeap.py
+++ b/MaxHeap.py
@@ -15,9 +15,9 @@ class MaxHeap:
 		self.__floatUp(len(self.heap) - 1)
 
 	def peek(self):
-		if self.heap[1]:
+		try:
 			return self.heap[1]
-		else:
+		except IndexError:
 			return False
 			
 	def pop(self):


### PR DESCRIPTION
Replaced if else conditionals with try except suite in order to catch IndexErrors if self.heap[1] is attempting to subscript an out of bounds index.

In response to issue #108.